### PR TITLE
Rename Http class to Connection

### DIFF
--- a/acceptance/tests/puppetserver_requests.rb
+++ b/acceptance/tests/puppetserver_requests.rb
@@ -1,26 +1,33 @@
 require 'beaker-http'
 
-test_name 'Ensure that requests can be built out to the puppetserver'
+test_name 'Ensure that requests can be built out to the puppetserver' do
 
-step 'install latest released puppet agent' do
-  install_puppet_agent_on(hosts)
-end
+  step 'install latest released puppet agent' do
+    install_puppet_agent_on(hosts)
+  end
 
-step 'install the latest puppet-server on the master' do
-  install_package(master, 'puppetserver')
-  on master, 'service puppetserver start'
-end
+  step 'install the latest puppet-server on the master' do
+    install_package(master, 'puppetserver')
+    on master, 'service puppetserver start'
+  end
 
-step 'generate a new beaker http connection object'
-beaker_http_connection = Beaker::Http::Connection.new(master)
+  step 'generate a new beaker http connection object'
+  http_connection = generate_new_http_connection(master)
 
-step 'configure the connection to connect to the master port'
-beaker_http_connection.connection.port = 8140
+  step 'configure the connection to connect to the master port' do
+    http_connection.url_prefix.port = 8140
+  end
 
-step 'configure ssl for the connection'
-beaker_http_connection.configure_private_key_and_cert_with_puppet
+  step 'call the environments endpoint on the puppetserver' do
+    response = http_connection.get('/puppet/v3/environments')
+    assert_equal(200, response.status)
+  end
 
-step 'call the environments endpoint on the puppetserver' do
-  response = beaker_http_connection.get('/puppet/v3/environments')
-  assert_equal(200, response.status)
+  step 'call the environments endpoint with the #https_request method' do
+    response = http_request("https://#{master.hostname}:8140/puppet/v3/environments",
+      :get,
+      http_connection.ssl['client_cert'],
+      http_connection.ssl['client_key'])
+    assert_equal(200, response.status)
+  end
 end

--- a/acceptance/tests/puppetserver_requests.rb
+++ b/acceptance/tests/puppetserver_requests.rb
@@ -1,0 +1,26 @@
+require 'beaker-http'
+
+test_name 'Ensure that requests can be built out to the puppetserver'
+
+step 'install latest released puppet agent' do
+  install_puppet_agent_on(hosts)
+end
+
+step 'install the latest puppet-server on the master' do
+  install_package(master, 'puppetserver')
+  on master, 'service puppetserver start'
+end
+
+step 'generate a new beaker http connection object'
+beaker_http_connection = Beaker::Http::Connection.new(master)
+
+step 'configure the connection to connect to the master port'
+beaker_http_connection.connection.port = 8140
+
+step 'configure ssl for the connection'
+beaker_http_connection.configure_private_key_and_cert_with_puppet
+
+step 'call the environments endpoint on the puppetserver' do
+  response = beaker_http_connection.get('/puppet/v3/environments')
+  assert_equal(200, response.status)
+end

--- a/beaker-http.gemspec
+++ b/beaker-http.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   #Run time dependencies
   spec.add_runtime_dependency 'json', '~> 1.8'
-  spec.add_runtime_dependency 'beaker', '~> 2.1', '>= 2.1.0'
+  spec.add_runtime_dependency 'beaker', '~> 3.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
 end

--- a/lib/beaker-http.rb
+++ b/lib/beaker-http.rb
@@ -5,5 +5,6 @@ require 'forwardable'
 require 'beaker'
 
 require 'beaker-http/helpers/puppet_helpers'
+require 'beaker-http/dsl/web_helpers'
 require "beaker-http/http"
 require 'beaker-http/middleware/response/faraday_beaker_logger'

--- a/lib/beaker-http/dsl/web_helpers.rb
+++ b/lib/beaker-http/dsl/web_helpers.rb
@@ -56,11 +56,7 @@ module Beaker::DSL::Helpers::WebHelpers
 
     connection.connection.options.timeout = options[:read_timeout] if options[:read_timeout]
 
-    if request_method == :post
-      response = connection.post { |conn| conn.body = body }
-    else
-      response = connection.get
-    end
+    response = connection.send(request_method) { |conn| conn.body = body }
     response
   end
 end

--- a/lib/beaker-http/dsl/web_helpers.rb
+++ b/lib/beaker-http/dsl/web_helpers.rb
@@ -54,7 +54,7 @@ module Beaker::DSL::Helpers::WebHelpers
     # ewwww
     connection.ssl[:verify] = false
 
-    connection.options.timeout = options[:read_timeout] if options[:read_timeout]
+    connection.connection.options.timeout = options[:read_timeout] if options[:read_timeout]
 
     if request_method == :post
       response = connection.post { |conn| conn.body = body }

--- a/lib/beaker-http/dsl/web_helpers.rb
+++ b/lib/beaker-http/dsl/web_helpers.rb
@@ -1,23 +1,43 @@
 module Beaker::DSL::Helpers::WebHelpers
 
-  def generate_new_http_connection(host=nil)
-    connection = Beaker::Http::Connection.new(options)
-
+  # Generates a new http connection object, using the ever-present options hash to
+  # configure the connection.
+  #
+  # @param host [Beaker::Host optional] supply a SUT host object; will use puppet on host
+  #    to configure certs, and use the options in the host object instead of the global.
+  # @return [Beaker::Http::Connection] an object wrapping the Faraday::Connection object.
+  def generate_new_http_connection(host = nil)
     if host
+      raise ArgumentError.new "host must be Beaker::Host, not #{host.class}" if !host.is_a?(Beaker::Host)
+      connection = Beaker::Http::Connection.new(host.options)
       connection.configure_private_key_and_cert_with_puppet(host)
+      connection
+    else
+      Beaker::Http::Connection.new(options)
     end
-
-    connection
   end
 
-  def https_request(url, request_method, cert=nil, key=nil, body=nil, options={})
+  # Make a single http request and discard the http connection object. Returns a Faraday::Response
+  # object that can be introspected for all response information.
+  #
+  # @param url [String] String that will be parsed into a URI object.
+  # @param request_method [Symbol] Represents any valid http verb.
+  # @param cert [OpenSSL::X509::Certificate] Certifcate for authentication.
+  # @param key [OpenSSL::PKey::RSA] Private Key for authentication.
+  # @param body [String, Hash] For requests that can send a body. Strings are sent unformatted and
+  #    Hashes are JSON.parsed by the Faraday Middleware.
+  # @param [Hash] options Hash of options extra options for the request
+  # @option options [Boolean] :read_timeout How long to wait before closing the connection.
+  # @return [Faraday::Response]
+  def http_request(url, request_method, cert=nil, key=nil, body=nil, options={})
     connection = generate_new_http_connection
+
 
     connection.url_prefix = URI.parse(url)
 
     if cert
       if cert.is_a?(OpenSSL::X509::Certificate)
-        connection.set_client_cert(cert)
+        connection.ssl['client_cert'] = cert
       else
         raise TypeError, "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
       end
@@ -25,14 +45,14 @@ module Beaker::DSL::Helpers::WebHelpers
 
     if key
       if key.is_a?(OpenSSL::PKey::RSA)
-        connection.set_client_key(key)
+        connection.ssl['client_key'] = key
       else
         raise TypeError, "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
       end
     end
 
     # ewwww
-    connection.connection.ssl[:verify] = false
+    connection.ssl[:verify] = false
 
     connection.options.timeout = options[:read_timeout] if options[:read_timeout]
 

--- a/lib/beaker-http/dsl/web_helpers.rb
+++ b/lib/beaker-http/dsl/web_helpers.rb
@@ -1,0 +1,46 @@
+module Beaker::DSL::Helpers::WebHelpers
+
+  def generate_new_http_connection(host=nil)
+    connection = Beaker::Http::Connection.new(options)
+
+    if host
+      connection.configure_private_key_and_cert_with_puppet(host)
+    end
+
+    connection
+  end
+
+  def https_request(url, request_method, cert=nil, key=nil, body=nil, options={})
+    connection = generate_new_http_connection
+
+    connection.url_prefix = URI.parse(url)
+
+    if cert
+      if cert.is_a?(OpenSSL::X509::Certificate)
+        connection.set_client_cert(cert)
+      else
+        raise TypeError, "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
+      end
+    end
+
+    if key
+      if key.is_a?(OpenSSL::PKey::RSA)
+        connection.set_client_key(key)
+      else
+        raise TypeError, "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
+      end
+    end
+
+    # ewwww
+    connection.connection.ssl[:verify] = false
+
+    connection.options.timeout = options[:read_timeout] if options[:read_timeout]
+
+    if request_method == :post
+      response = connection.post { |conn| conn.body = body }
+    else
+      response = connection.get
+    end
+    response
+  end
+end

--- a/lib/beaker-http/helpers/puppet_helpers.rb
+++ b/lib/beaker-http/helpers/puppet_helpers.rb
@@ -2,6 +2,10 @@ module Beaker
   module Http
     module Helpers
 
+      # Given a Beaker::Host object, introspect the host for the CA cert and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the CA cert
+      # @return [String] File path to the CA cert saved on the coordinator
       def get_host_cacert(host)
         cacert_on_host= host.puppet['localcacert']
         # puppet may not have laid down the cacert yet, so check to make sure
@@ -16,6 +20,10 @@ module Beaker
         ca_cert_file
       end
 
+      # Given a Beaker::Host object, introspect the host for the private key and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the private key
+      # @return [String] A String of the private key
       def get_host_private_key(host)
         private_key = host.puppet['hostprivkey']
         # puppet may not have laid down the private_key yet, so check to make sure
@@ -24,6 +32,10 @@ module Beaker
         host.execute("cat #{private_key}", :silent => true)
       end
 
+      # Given a Beaker::Host object, introspect the host for the host cert and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the host cert
+      # @return [String] A String of the host cert
       def get_host_cert(host)
         hostcert = host.puppet['hostcert']
         # puppet may not have laid down the hostcert yet, so check to make sure

--- a/lib/beaker-http/http.rb
+++ b/lib/beaker-http/http.rb
@@ -8,30 +8,21 @@ module Beaker
       extend Forwardable
 
       attr_accessor :connection
-      attr_reader :host
 
-      def initialize(host)
-        @host = host
-
-        if @host.is_a?(Beaker::Host)
-          @connection = create_default_connection
-        else
-          raise "Argument host must be Beaker::Host"
-        end
-
-        connection.url_prefix.host = host.hostname
+      def initialize(options)
+        @connection = create_default_connection(options)
       end
 
-      def_delegators :@connection, :get, :post, :put, :delete, :head, :patch
+      def_delegators :connection, :get, :post, :put, :delete, :head, :patch, :scheme, :scheme=, :host, :host=, :port, :port=, :url_prefix, :url_prefix=
 
-      def create_default_connection
+      def create_default_connection(options)
         Faraday.new do |conn|
           conn.request :json
 
           conn.response :follow_redirects
           conn.response :raise_error
           conn.response :json, :content_type => /\bjson$/
-          conn.response :faraday_beaker_logger, @host, bodies: true
+          conn.response :faraday_beaker_logger, options[:logger], bodies: true
 
           conn.adapter :net_http
         end
@@ -44,22 +35,39 @@ module Beaker
         nil
       end
 
+      def set_cacert(ca_file)
+        connection.ssl['ca_file'] = ca_file
+        connection.scheme = 'https'
+      end
+
+      def set_client_key(client_key)
+        connection.ssl['client_key'] = client_key
+      end
+
+      def set_client_cert(client_cert)
+        connection.ssl['client_cert'] = client_cert
+      end
+
       # Use this method if you are connecting as a user to the system; it will
       # provide the correct SSL context but not provide authentication.
-      def configure_cacert_only_with_puppet
-        connection.ssl['ca_file'] = get_host_cacert(@host)
-        connection.scheme = 'https'
+      def configure_cacert_with_puppet(host)
+        set_cacert(get_host_cacert(host))
+        connection.host = host.hostname
         nil
       end
 
       # Use this method if you want to connect to the system using certificate
-      # based authentication.
-      def configure_private_key_and_cert_with_puppet
-        configure_cacert_only_with_puppet
-        client_key = get_host_private_key(@host)
-        client_cert = get_host_cert(@host)
-        connection.ssl['client_key'] = OpenSSL::PKey.read(client_key)
-        connection.ssl['client_cert'] = OpenSSL::X509::Certificate.new(client_cert)
+      # based authentication. This method will provide the ssl context and use
+      # the private key and cert from the host provided for authentication.
+      def configure_private_key_and_cert_with_puppet(host)
+        configure_cacert_with_puppet(host)
+
+        client_key_raw = get_host_private_key(host)
+        client_cert_raw = get_host_cert(host)
+
+        set_client_key(OpenSSL::PKey.read(client_key_raw))
+        set_client_cert(OpenSSL::X509::Certificate.new(client_cert_raw))
+
         nil
       end
 

--- a/lib/beaker-http/http.rb
+++ b/lib/beaker-http/http.rb
@@ -22,7 +22,7 @@ module Beaker
         @connection = create_default_connection(options)
       end
 
-      def_delegators :connection, :get, :post, :put, :delete, :head, :patch, :url_prefix, :url_prefix=, :ssl, :options
+      def_delegators :connection, :get, :post, :put, :delete, :head, :patch, :url_prefix, :url_prefix=, :ssl
 
       def create_default_connection(options)
         Faraday.new do |conn|

--- a/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
+++ b/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
@@ -3,7 +3,7 @@ module Beaker
     class FaradayBeakerLogger < Faraday::Response::Middleware
       extend Forwardable
 
-      DEFAULT_OPTIONS = { :bodies => false }
+      DEFAULT_OPTIONS = { :bodies => true }
 
       def initialize(app, logger, options = {} )
         super(app)
@@ -41,17 +41,12 @@ module Beaker
         end
       end
 
-      def pretty_inspect(body)
-        require 'pp' unless body.respond_to?(:pretty_inspect)
-        body.pretty_inspect
-      end
-
       def log_body?(type)
         case @options[:bodies]
         when Hash then @options[:bodies][type]
         else @options[:bodies]
-        end
       end
+    end
 
     end
   end

--- a/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
+++ b/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
@@ -5,15 +5,16 @@ module Beaker
 
       DEFAULT_OPTIONS = { :bodies => false }
 
-      def initialize(app, host, options = {} )
+      def initialize(app, logger, options = {} )
         super(app)
-        @logger = host.logger
+        @logger = logger
         @options = DEFAULT_OPTIONS.merge(options)
       end
 
       def_delegators :@logger, :trace, :debug, :info, :notify, :warn
 
       def call(env)
+        @start_time = Time.now
         info "#{env.method.upcase}: #{env.url.to_s}"
         debug "REQUEST HEADERS:\n#{dump_headers env.request_headers}"
         debug "REQUEST BODY:\n#{dump_body env[:body]}" if env[:body] && log_body?(:request)
@@ -22,6 +23,7 @@ module Beaker
 
       def on_complete(env)
         info "RESPONSE CODE: #{env.status.to_s}"
+        debug "ELAPSED TIME: #{Time.now - @start_time}"
         debug "RESPONSE HEADERS:\n#{dump_headers env.response_headers}"
         debug "RESPONSE BODY:\n#{dump_body env[:body]}" if env[:body] && log_body?(:response)
       end

--- a/spec/beaker-http/dsl/web_helpers_spec.rb
+++ b/spec/beaker-http/dsl/web_helpers_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLWebHelpers
+  include Beaker::DSL::Helpers
+
+  attr_accessor :options
+
+  def initialize
+    @options = { logger: Beaker::Logger.new }
+  end
+end
+
+describe ClassMixedWithDSLWebHelpers do
+
+  describe '#generate_new_http_connection' do
+
+    it 'raises an argument error if a non Beaker::Host is supplied' do
+      expect{subject.generate_new_http_connection(Object.new)}.to raise_error(ArgumentError)
+    end
+
+    it 'raises no errors when no argument is supplied' do
+      expect{subject.generate_new_http_connection}.to_not raise_error
+    end
+
+    context 'when passed a beaker host' do
+      unixhost = { roles:     ['test_role'],
+                   'platform' => 'debian-7-x86_64' }
+      let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
+      let(:mock_options) { {:logger => Beaker::Logger.new} }
+      let(:mock_connection) {double('connection')}
+
+      it 'configures the connection object' do
+        expect(mock_connection).to receive(:configure_private_key_and_cert_with_puppet).with(host)
+        expect(Beaker::Http::Connection).to receive(:new).with(mock_options).and_return(mock_connection)
+        allow(host).to receive(:options).and_return(mock_options)
+        expect{subject.generate_new_http_connection(host)}.to_not raise_error
+      end
+    end
+
+  end
+
+  describe '#http_request' do
+    let (:url) {"http://wwww.test.com"}
+    let (:request_method) { :get }
+    let (:mock_response) {double('reponse')}
+    let (:mock_connection) { subject.generate_new_http_connection }
+    let (:read_timeout) {double('read_timeout')}
+
+    it 'sends a GET request to the url with the minimum required params' do
+      expect(mock_connection).to receive(:get).and_return(mock_response)
+      expect(URI).to receive(:parse).with(url).and_call_original
+      expect(mock_connection).to receive(:url_prefix=).and_call_original
+      expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+      expect(subject.http_request(url, request_method)).to eq(mock_response)
+    end
+
+    context 'when the request_method is POST' do
+      let (:request_method) { :post }
+      let (:body) {double('body')}
+      let (:conn) { double('conn') }
+
+      it 'sends a body along in the request' do
+        expect(conn).to receive(:body=).with(body)
+        expect(mock_connection).to receive(:post).and_yield(conn).and_return(mock_response)
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+        expect(subject.http_request(url, request_method, nil, nil, body, {})).to eq(mock_response)
+      end
+    end
+
+    it 'can set the timeout from the options hash passed in' do
+      expect(mock_connection).to receive(:get).and_return(mock_response)
+      expect(URI).to receive(:parse).with(url).and_call_original
+      expect(mock_connection).to receive(:url_prefix=).and_call_original
+      expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+      expect(subject.http_request(url, request_method, nil, nil, nil, :read_timeout => read_timeout)).to eq(mock_response)
+      expect(mock_connection.options.timeout).to eq(read_timeout)
+    end
+
+    context 'with a key and cert provided' do
+      let (:key) {'key'}
+      let (:cert) {'cert'}
+      it 'checks to ensure they are valid types and then adds them to the request' do
+
+        expect(mock_connection).to receive(:get).and_return(mock_response)
+        expect(key).to receive(:is_a?).with(OpenSSL::PKey::RSA).and_return(true)
+        expect(cert).to receive(:is_a?).with(OpenSSL::X509::Certificate).and_return(true)
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+
+        expect(subject.http_request(url, request_method, cert, key)).to eq(mock_response)
+        expect(mock_connection.ssl['client_key']).to eq(key)
+        expect(mock_connection.ssl['client_cert']).to eq(cert)
+      end
+
+      it 'errors when an invalid key is provided' do
+        expect(mock_connection).to_not receive(:get)
+        expect(key).to receive(:is_a?).with(OpenSSL::PKey::RSA).and_call_original
+        expect(cert).to receive(:is_a?).with(OpenSSL::X509::Certificate).and_return(true)
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+        expect{subject.http_request(url, request_method, cert, key)}.to raise_error(TypeError)
+      end
+
+      it 'errors when an invalid cert is provided' do
+        expect(mock_connection).to_not receive(:get)
+        expect(key).to_not receive(:is_a?).with(OpenSSL::PKey::RSA)
+        expect(cert).to receive(:is_a?).with(OpenSSL::X509::Certificate).and_call_original
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+        expect{subject.http_request(url, request_method, cert, key)}.to raise_error(TypeError)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/beaker-http/dsl/web_helpers_spec.rb
+++ b/spec/beaker-http/dsl/web_helpers_spec.rb
@@ -75,7 +75,7 @@ describe ClassMixedWithDSLWebHelpers do
       expect(mock_connection).to receive(:url_prefix=).and_call_original
       expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
       expect(subject.http_request(url, request_method, nil, nil, nil, :read_timeout => read_timeout)).to eq(mock_response)
-      expect(mock_connection.options.timeout).to eq(read_timeout)
+      expect(mock_connection.connection.options.timeout).to eq(read_timeout)
     end
 
     context 'with a key and cert provided' do

--- a/spec/beaker-http/dsl/web_helpers_spec.rb
+++ b/spec/beaker-http/dsl/web_helpers_spec.rb
@@ -54,6 +54,17 @@ describe ClassMixedWithDSLWebHelpers do
       expect(subject.http_request(url, request_method)).to eq(mock_response)
     end
 
+    context 'send a DELETE request to the url with the minimum required params' do
+      let (:request_method) { :delete }
+      it 'sends a DELETE request to the url with the minimum required params' do
+        expect(mock_connection).to receive(:delete).and_return(mock_response)
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+        expect(subject.http_request(url, request_method)).to eq(mock_response)
+      end
+    end
+
     context 'when the request_method is POST' do
       let (:request_method) { :post }
       let (:body) {double('body')}
@@ -67,6 +78,23 @@ describe ClassMixedWithDSLWebHelpers do
         expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
         expect(subject.http_request(url, request_method, nil, nil, body, {})).to eq(mock_response)
       end
+    end
+
+
+    context 'when the request_method is PUT' do
+      let (:request_method) { :put }
+      let (:body) {double('body')}
+      let (:conn) { double('conn') }
+
+      it 'sends a body along in the request' do
+        expect(conn).to receive(:body=).with(body)
+        expect(mock_connection).to receive(:put).and_yield(conn).and_return(mock_response)
+        expect(URI).to receive(:parse).with(url).and_call_original
+        expect(mock_connection).to receive(:url_prefix=).and_call_original
+        expect(subject).to receive(:generate_new_http_connection).and_return(mock_connection)
+        expect(subject.http_request(url, request_method, nil, nil, body, {})).to eq(mock_response)
+      end
+
     end
 
     it 'can set the timeout from the options hash passed in' do

--- a/spec/beaker-http/http_spec.rb
+++ b/spec/beaker-http/http_spec.rb
@@ -32,7 +32,7 @@ module Beaker
         end
 
         it 'routes other useful methods to the connection object' do
-          useful_methods = [:url_prefix, :url_prefix=, :ssl, :options]
+          useful_methods = [:url_prefix, :url_prefix=, :ssl]
 
           useful_methods.each do |method|
             expect(subject.connection).to receive(method)

--- a/spec/beaker-http/http_spec.rb
+++ b/spec/beaker-http/http_spec.rb
@@ -4,15 +4,11 @@ module Beaker
   module Http
     describe Connection do
 
-      let(:host) {double('host')}
+      let(:options) {{ :logger => Beaker::Logger.new}}
 
-      subject { Connection.new( host ) }
+      subject { Connection.new( options ) }
 
-
-      context 'with a beaker host passed in' do
-        unixhost = { roles:     ['test_role'],
-                     'platform' => 'debian-7-x86_64' }
-        let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
+      context 'with a beaker logger in the options passed in ' do
 
         it 'does not raise errors' do
           expect {subject}.to_not raise_error
@@ -22,14 +18,8 @@ module Beaker
           expect(subject.connection).to be_instance_of(Faraday::Connection)
         end
 
-        it 'sets a Beaker host object as the instance host object' do
-          expect(subject.host).to be_kind_of(Beaker::Host)
-        end
-
         it 'sets the middleware stack' do
-
           expect(subject.connection.builder.handlers).to eq(HttpHelpers::DEFAULT_MIDDLEWARE_STACK)
-
         end
 
         it 'routes all http verbs to the connection object' do
@@ -41,10 +31,13 @@ module Beaker
           end
         end
 
-        it 'sets the connection host to the hostname of the beaker host' do
-          allow(host).to receive(:hostname).and_return('puppet.com')
-          expect(subject.connection.host).to eq('puppet.com')
-          subject
+        it 'routes other useful methods to the connection object' do
+          useful_methods = [:url_prefix, :url_prefix=, :ssl, :options]
+
+          useful_methods.each do |method|
+            expect(subject.connection).to receive(method)
+            subject.send(method)
+          end
         end
 
         describe '#remove_error_checking' do
@@ -54,26 +47,32 @@ module Beaker
           end
         end
 
-        describe '#configure_cacert_only_with_puppet'
-        it 'adds a ca_cert to the connection and changes the scheme to https' do
-          allow(subject).to receive(:get_host_cacert).with(host).and_return('ca_file')
-          subject.configure_cacert_only_with_puppet
-          expect(subject.connection.ssl['ca_file']).to eq('ca_file')
-          expect(subject.connection.scheme).to eq('https')
-        end
+        context 'with a beaker host passed in' do
+        unixhost = { roles:     ['test_role'],
+                     'platform' => 'debian-7-x86_64' }
+        let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
 
-        describe '#configure_private_key_and_cert_with_puppet'
-        it 'calls #configure_cacert_only_with_puppet and adds the host private key and cert' do
-          allow(subject).to receive(:configure_cacert_only_with_puppet)
-          allow(subject).to receive(:get_host_private_key).with(host).and_return('private_key')
-          allow(subject).to receive(:get_host_cert).with(host).and_return('host_cert')
+          describe '#configure_cacert_with_puppet'
+          it 'adds a ca_cert to the connection and changes the scheme to https' do
+            allow(subject).to receive(:get_host_cacert).with(host).and_return('ca_file')
+            subject.configure_cacert_with_puppet(host)
+            expect(subject.connection.ssl['ca_file']).to eq('ca_file')
+            expect(subject.connection.scheme).to eq('https')
+          end
 
-          allow(OpenSSL::PKey).to receive(:read).with('private_key').and_return('ssl_private_key')
-          allow(OpenSSL::X509::Certificate).to receive(:new).with('host_cert').and_return('ssl_host_cert')
+          describe '#configure_private_key_and_cert_with_puppet'
+          it 'calls #configure_cacert_only_with_puppet and adds the host private key and cert' do
+            allow(subject).to receive(:configure_cacert_with_puppet)
+            allow(subject).to receive(:get_host_private_key).with(host).and_return('private_key')
+            allow(subject).to receive(:get_host_cert).with(host).and_return('host_cert')
 
-          subject.configure_private_key_and_cert_with_puppet
-          expect(subject.connection.ssl['client_key']).to eq('ssl_private_key')
-          expect(subject.connection.ssl['client_cert']).to eq('ssl_host_cert')
+            allow(OpenSSL::PKey).to receive(:read).with('private_key').and_return('ssl_private_key')
+            allow(OpenSSL::X509::Certificate).to receive(:new).with('host_cert').and_return('ssl_host_cert')
+
+            subject.configure_private_key_and_cert_with_puppet(host)
+            expect(subject.connection.ssl['client_key']).to eq('ssl_private_key')
+            expect(subject.connection.ssl['client_cert']).to eq('ssl_host_cert')
+          end
         end
       end
     end

--- a/spec/beaker-http/middleware/response/faraday_beaker_logger_spec.rb
+++ b/spec/beaker-http/middleware/response/faraday_beaker_logger_spec.rb
@@ -39,7 +39,7 @@ describe Beaker::Http::FaradayBeakerLogger do
       end
     end
 
-    it 'sends extra and debug requests logging to the logger' do
+    it 'sends extra debug requests to the logger' do
       expect(host.logger).to receive(:info).with('POST: http://test.com/path').once
       expect(host.logger).to receive(:info).with(/RESPONSE CODE: 201/).once
       expect(host.logger).to receive(:debug).with(/RESPONSE BODY:/).once

--- a/spec/beaker-http/middleware/response/faraday_beaker_logger_spec.rb
+++ b/spec/beaker-http/middleware/response/faraday_beaker_logger_spec.rb
@@ -3,29 +3,25 @@ require 'spec_helper'
 describe Beaker::Http::FaradayBeakerLogger do
 
   let(:conn) { Faraday.new(:url => 'http://test.com/path') }
-  let(:host) {
-    unixhost = { roles:     ['test_role'],
-                 'platform' => 'debian-7-x86_64' }
-    host = Beaker::Host.create('deb7', unixhost, {})
-    host.logger = Beaker::Logger.new
-    host
-  }
-
+  let (:logger) { Beaker::Logger.new }
 
   context 'with log bodies turned off' do
 
     before do
-      conn.builder.insert(0, Beaker::Http::FaradayBeakerLogger, host)
+      conn.builder.insert(0, Beaker::Http::FaradayBeakerLogger, logger, :bodies => false)
       conn.adapter :test do |stub|
         stub.get('/path') {[200, {}, 'success']}
       end
     end
 
     it 'sends info and debug requests to the logger' do
-      expect(host.logger).to receive(:info).with('GET: http://test.com/path').once
-      expect(host.logger).to receive(:info).with(/RESPONSE CODE: 200/).once
-      expect(host.logger).to receive(:debug).with(/REQUEST HEADERS:/).once
-      expect(host.logger).to receive(:debug).with(/RESPONSE HEADERS:/).once
+      expect(logger).to receive(:info).with('GET: http://test.com/path').once
+      expect(logger).to receive(:info).with(/RESPONSE CODE: 200/).once
+      expect(logger).to receive(:debug).with(/ELAPSED TIME:/).once
+      expect(logger).to receive(:debug).with(/REQUEST HEADERS:/).once
+      expect(logger).to receive(:debug).with(/RESPONSE HEADERS:/).once
+      expect(logger).to_not receive(:debug).with(/RESPONSE BODY:/)
+      expect(logger).to_not receive(:debug).with(/REQUEST BODY:/)
       conn.get
     end
   end
@@ -33,19 +29,20 @@ describe Beaker::Http::FaradayBeakerLogger do
   context 'with log bodies turned on' do
 
     before do
-      conn.builder.insert(0, Beaker::Http::FaradayBeakerLogger, host, :bodies => true)
+      conn.builder.insert(0, Beaker::Http::FaradayBeakerLogger, logger, :bodies => true)
       conn.adapter :test do |stub|
         stub.post('/path') {[201, {}, 'success']}
       end
     end
 
     it 'sends extra debug requests to the logger' do
-      expect(host.logger).to receive(:info).with('POST: http://test.com/path').once
-      expect(host.logger).to receive(:info).with(/RESPONSE CODE: 201/).once
-      expect(host.logger).to receive(:debug).with(/RESPONSE BODY:/).once
-      expect(host.logger).to receive(:debug).with(/REQUEST BODY:/).once
-      expect(host.logger).to receive(:debug).with(/REQUEST HEADERS:/).once
-      expect(host.logger).to receive(:debug).with(/RESPONSE HEADERS:/).once
+      expect(logger).to receive(:info).with('POST: http://test.com/path').once
+      expect(logger).to receive(:info).with(/RESPONSE CODE: 201/).once
+      expect(logger).to receive(:debug).with(/ELAPSED TIME:/).once
+      expect(logger).to receive(:debug).with(/RESPONSE BODY:\nsuccess/).once
+      expect(logger).to receive(:debug).with(/REQUEST BODY:\nBODY MOVIN'/).once
+      expect(logger).to receive(:debug).with(/REQUEST HEADERS:/).once
+      expect(logger).to receive(:debug).with(/RESPONSE HEADERS:/).once
       conn.post() { |connection| connection.body = "BODY MOVIN'" }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,10 @@
 require 'beaker-http'
+
+module HttpHelpers
+  DEFAULT_MIDDLEWARE_STACK = [FaradayMiddleware::EncodeJson,
+                              FaradayMiddleware::FollowRedirects,
+                              Faraday::Response::RaiseError,
+                              FaradayMiddleware::ParseJson,
+                              Beaker::Http::FaradayBeakerLogger,
+                              Faraday::Adapter::NetHttp]
+end


### PR DESCRIPTION
This commit changes the Http class to be renamed to Connection; this
fits in better with the `Faraday::Connection` class that it depends
upon. This PR also removes some of the helper methods that were
unnecessary, as they were methods simply wrapping settings on the Faraday
object itself.

Also included in this commit is a simple test that demonstrates how
to use the Http class in a test, installing the puppetserver and making
a simple request to the environments endpoint.
