### PR TITLE
(BKR-775) fix middleware logger pretty_inspect

### DIFF
--- a/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
+++ b/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
@@ -33,6 +33,11 @@ module Beaker
         headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
       end
 
+      def pretty_inspect(body)
+        require 'pp' unless body.respond_to?(:pretty_inspect)
+        body.pretty_inspect
+      end
+
       def dump_body(body)
         if body.respond_to?(:to_str)
           body.to_str


### PR DESCRIPTION
There was a missing implementation of pretty_inspect in the faraday
middleware logger that errored out if the middleware returned an object
that didn't respond to :to_str. This commit adds in that implementation
and adds a spec test for that functionality.